### PR TITLE
Unscented Kalman inversion

### DIFF
--- a/examples/convective_adjustment_perfect_model_calibration_uki.jl
+++ b/examples/convective_adjustment_perfect_model_calibration_uki.jl
@@ -1,0 +1,157 @@
+pushfirst!(LOAD_PATH, joinpath(@__DIR__, ".."))
+
+using LinearAlgebra
+using Distributions
+using Oceananigans
+using Oceananigans.Units
+using Oceananigans.Models.HydrostaticFreeSurfaceModels: ColumnEnsembleSize
+using Oceananigans.TurbulenceClosures: ConvectiveAdjustmentVerticalDiffusivity
+using OceanTurbulenceParameterEstimation
+using EnsembleKalmanProcesses.ParameterDistributionStorage
+#####
+##### Parameters
+#####
+
+Nz = 32
+Lz = 128
+Qᵇ = 1e-8
+Qᵘ = -1e-5
+Δt = 20.0
+f₀ = 1e-4
+N² = 1e-5
+stop_time = 10hours
+save_interval = 1hour
+experiment_name = "convective_adjustment"
+data_path = experiment_name * ".jld2"
+generate_observations = false
+
+# "True" parameters to be estimated by calibration
+convective_κz = 1.0
+background_κz = 1e-4
+convective_νz = 0.9
+background_νz = 1e-5
+
+θ★ = [convective_κz, background_κz]
+
+Nθ = length(θ★)
+# UKI uses 2Nθ + 1 particles
+ensemble_size = 2Nθ+1
+#####
+##### Generate synthetic observations
+#####
+
+if generate_observations || !(isfile(data_path))
+    grid = RegularRectilinearGrid(size=Nz, z=(-Lz, 0), topology=(Flat, Flat, Bounded))
+    closure = ConvectiveAdjustmentVerticalDiffusivity(; convective_κz, background_κz, convective_νz, background_νz)
+    coriolis = FPlane(f=f₀)
+                                          
+    u_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵘ))
+    b_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵇ), bottom = GradientBoundaryCondition(N²))
+    
+    model = HydrostaticFreeSurfaceModel(grid = grid,
+                                        tracers = :b,
+                                        buoyancy = BuoyancyTracer(),
+                                        boundary_conditions = (; u=u_bcs, b=b_bcs),
+                                        coriolis = coriolis,
+                                        closure = closure)
+                                        
+    set!(model, b = (x, y, z) -> N² * z)
+    
+    simulation = Simulation(model; Δt, stop_time)
+    
+    simulation.output_writers[:fields] = JLD2OutputWriter(model, merge(model.velocities, model.tracers),
+                                                          schedule = TimeInterval(save_interval),
+                                                          prefix = experiment_name,
+                                                          array_type = Array{Float64},
+                                                          field_slicer = nothing,
+                                                          force = true)
+    
+    run!(simulation)
+end
+
+#####
+##### Load truth data as observations
+#####
+
+data_path = experiment_name * ".jld2"
+
+observations = OneDimensionalTimeSeries(data_path, field_names=(:u, :b), normalize=ZScore)
+
+#####
+##### Set up ensemble model
+#####
+
+column_ensemble_size = ColumnEnsembleSize(Nz=Nz, ensemble=(ensemble_size, 1), Hz=1)
+ensemble_grid = RegularRectilinearGrid(size=column_ensemble_size, z = (-Lz, 0), topology = (Flat, Flat, Bounded))
+closure_ensemble = [ConvectiveAdjustmentVerticalDiffusivity(; convective_κz, background_κz, convective_νz, background_νz) for i = 1:ensemble_grid.Nx, j = 1:ensemble_grid.Ny]
+coriolis_ensemble = [FPlane(f=f₀) for i = 1:ensemble_grid.Nx, j = 1:ensemble_grid.Ny]
+
+ensemble_b_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵇ), bottom = GradientBoundaryCondition(N²))
+ensemble_u_bcs = FieldBoundaryConditions(top = FluxBoundaryCondition(Qᵘ))
+
+ensemble_model = HydrostaticFreeSurfaceModel(grid = ensemble_grid,
+                                             tracers = :b,
+                                             buoyancy = BuoyancyTracer(),
+                                             boundary_conditions = (; u=ensemble_u_bcs, b=ensemble_b_bcs),
+                                             coriolis = coriolis_ensemble,
+                                             closure = closure_ensemble)
+
+set!(ensemble_model, b = (x, y, z) -> N² * z)
+
+ensemble_simulation = Simulation(ensemble_model; Δt, stop_time)
+
+pop!(ensemble_simulation.diagnostics, :nan_checker)
+#####
+##### Build free parameters
+#####
+
+
+priors = (
+    convective_κz = ConstrainedNormal(0.0, 1.0, 0.0, 4*convective_κz),
+    background_κz = ConstrainedNormal(0.0, 1.0, 0.0, 4*background_κz),
+    # convective_νz = ConstrainedNormal(0.0, 1.0, 0.0, 2*convective_νz),
+    # background_νz = ConstrainedNormal(0.0, 1.0, 0.0, 2*background_νz)
+)
+
+
+free_parameters = FreeParameters(priors)
+
+#####
+##### Build the Inverse Problem
+#####
+
+calibration = InverseProblem(observations, ensemble_simulation, free_parameters)
+
+# forward_map(calibration, [θ★ for _ in 1:ensemble_size])
+x = forward_map(calibration, [θ★ for _ in 1:ensemble_size])[1:1, :]
+y = observation_map(calibration)
+
+using Plots, LinearAlgebra
+
+iterations = 10
+
+prior_mean = fill(0.0, Nθ) 
+prior_cov = Matrix(Diagonal(fill(1.0, Nθ)))
+α_reg = 1.0   # regularization parameter 
+update_freq = 1
+# error is about 5%
+noise_covariance = 0.05^2
+eki = UnscentedKalmanInversion(calibration, prior_mean, prior_cov; noise_covariance=noise_covariance, α_reg = α_reg, update_freq=update_freq)
+
+iterate!(eki; iterations = iterations)
+
+θ_mean, θθ_cov, θθ_std_arr, err =  UnscentedKalmanInversionPostprocess(eki)
+
+# Parameter plot
+N_iter = size(θ_mean, 2)
+ites = Array(LinRange(1, N_iter, N_iter))
+p1 = plot(ites, grid = false, θ_mean[1, :], yerror = θθ_std_arr[1, :], label = "θ1")
+plot!(ites, fill(θ★[1], N_iter), linestyle = :dash, linecolor = :grey, label = nothing)
+
+plot!(ites, grid = false, θ_mean[2, :], yerror = θθ_std_arr[2, :], label = "θ2", xaxis = "Iterations")
+plot!(ites, fill(θ★[2], N_iter), linestyle = :dash, linecolor = :grey, label = nothing, yaxis=("Parameters", :log10))
+
+# Error plot
+p2 = plot(ites[1:length(err)], grid = false, err, xaxis = "Iterations", yaxis = "Error", reuse = false)
+plot(p1, p2,  layout = @layout[a; b])
+

--- a/src/EnsembleKalmanInversions.jl
+++ b/src/EnsembleKalmanInversions.jl
@@ -17,18 +17,40 @@ function lognormal_with_mean_std(mean, std)
     return LogNormal(μ, σ)
 end
 
+struct ConstrainedNormal{FT}
+    # θ is the original constrained paramter, θ̃ is the unconstrained parameter ~ N(μ, σ)
+    # θ = lower_bound + (upper_bound - lower_bound)/（1 + exp(θ̃)）
+    μ::FT
+    σ::FT
+    lower_bound::FT
+    upper_bound::FT
+end
+
 # Model priors are sometimes constrained; EKI deals with unconstrained, Normal priors.
 convert_prior(prior::LogNormal) = Normal(prior.μ, prior.σ)
 convert_prior(prior::Normal) = prior
-convert_prior(constrained_prior) = @error "We don't know how to transform a $(typeof(constrained_prior)) distribution to a Normal distribution."
+convert_prior(prior::ConstrainedNormal) = Normal(prior.μ, prior.σ)
+
 
 # Convert parameters to unconstrained for EKI
 forward_parameter_transform(::LogNormal, parameter) = log(parameter)
 forward_parameter_transform(::Normal, parameter) = parameter
+forward_parameter_transform(cn::ConstrainedNormal, parameter) = log((cn.upper_bound - parameter)/(cn.upper_bound - cn.lower_bound))
 
 # Convert parameters from unconstrained (EKI) to constrained
 inverse_parameter_transform(::LogNormal, parameter) = exp(parameter)
 inverse_parameter_transform(::Normal, parameter) = parameter
+inverse_parameter_transform(cn::ConstrainedNormal, parameter) = cn.lower_bound+(cn.upper_bound - cn.lower_bound)/(1 + exp(parameter))
+
+# Convert covariance from unconstrained (EKI) to constrained
+inverse_covariance_transform(::Tuple{Vararg{LogNormal}}, parameters, covariance) = Diagonal(exp.(parameters)) * covariance * Diagonal(exp.(parameters))
+inverse_covariance_transform(::Tuple{Vararg{Normal}}, parameters, covariance) = covariance
+function inverse_covariance_transform(cn::Tuple{Vararg{ConstrainedNormal}}, parameters, covariance)
+    upper_bound = [cn[i].upper_bound for i = 1:length(cn)]
+    lower_bound = [cn[i].lower_bound for i = 1:length(cn)]
+    dT = Diagonal(-(upper_bound - lower_bound) .* exp.(parameters)./(1.0 .+ exp.(parameters)).^2) 
+    return dT * covariance * dT'
+end
 
 mutable struct EnsembleKalmanInversion{I, P, E, M, O, F, S, D}
     inverse_problem :: I
@@ -110,6 +132,72 @@ function EnsembleKalmanInversion(inverse_problem; noise_covariance=1e-2)
     ensemble_kalman_process = EnsembleKalmanProcess(initial_ensemble, y, Γy, Inversion())
 
     return EnsembleKalmanInversion(inverse_problem, parameter_distribution, ensemble_kalman_process, y, Γy, G, 0, [], Set())
+end
+
+"""
+UnscentedKalmanInversion Constructor 
+inverse_problem         : inverse problem
+prior_mean::Array{FT}   : prior mean
+prior_cov::Array{FT, 2} : prior covariance
+noise_covariance::FT    : observation error covariance
+α_reg::FT               : regularization parameter toward `u0` (0 < `α_reg` ≤ 1), default should be 1, without regulariazion
+update_freq::IT : set to 0 when the inverse problem is not identifiable (default), 
+                  namely the inverse problem has multiple solutions, 
+                  the covariance matrix will represent only the sensitivity of the parameters, 
+                  instead of posterior covariance information;
+                  set to 1 (or anything > 0) when the inverse problem is identifiable, and 
+                  the covariance matrix will converge to a good approximation of the 
+                  posterior covariance with an uninformative prior.
+                  
+"""
+function UnscentedKalmanInversion(inverse_problem, prior_mean, prior_cov; noise_covariance=1e-2, α_reg = 1.0, update_freq = 0)
+    free_parameters = inverse_problem.free_parameters
+    original_priors = free_parameters.priors
+
+    transformed_priors = [Parameterized(convert_prior(prior)) for prior in original_priors]
+    no_constraints = [[no_constraint()] for _ in transformed_priors]
+    parameter_distribution = ParameterDistribution(transformed_priors, no_constraints, collect(string.(free_parameters.names)))
+
+    # Build EKP-friendly observations "y" and the covariance matrix of observational uncertainty "Γy"
+    y = dropdims(observation_map(inverse_problem), dims=2) # length(forward_map_output) column vector
+    Γy = construct_noise_covariance(noise_covariance, y)
+
+    # The closure G(θ) maps (N_params, ensemble_size) array to (length(forward_map_output), ensemble_size)
+    function G(θ) 
+        batch_size = size(θ, 2)
+        inverted_parameters = [inverse_parameter_transform.(values(original_priors), θ[:, i]) for i in 1:batch_size]
+        return forward_map(inverse_problem, inverted_parameters)
+    end
+
+    ensemble_kalman_process = EnsembleKalmanProcess(y, Γy, Unscented(prior_mean, prior_cov, α_reg, update_freq))
+
+    return EnsembleKalmanInversion(inverse_problem, parameter_distribution, ensemble_kalman_process, y, Γy, G, 0, [], Set())
+end
+
+# return:
+# mean : N_iter × Nθ mean matrix
+# cov  : N_iter vector of Nθ × Nθ covariance matrix
+# std  : N_iter × Nθ standard deviation matrix
+# err  : N_iter error array
+function UnscentedKalmanInversionPostprocess(eki)
+
+    original_priors = eki.inverse_problem.free_parameters.priors
+    θ_mean_raw = hcat(eki.ensemble_kalman_process.process.u_mean...)
+    θθ_cov_raw = eki.ensemble_kalman_process.process.uu_cov
+    
+    θ_mean = similar(θ_mean_raw)
+    θθ_cov= similar(θθ_cov_raw)
+    θθ_std_arr = similar(θ_mean_raw)
+    for i = 1:size(θ_mean, 2)
+        θ_mean[:, i] = inverse_parameter_transform.(values(original_priors), θ_mean_raw[:, i])
+        θθ_cov[i] = inverse_covariance_transform(values(original_priors), θ_mean_raw[:, i], θθ_cov_raw[i])
+    
+        for j in 1:size(θ_mean, 1)
+            θθ_std_arr[j, i] = sqrt(θθ_cov[i][j, j])
+        end
+    end
+
+    return θ_mean, θθ_cov, θθ_std_arr, eki.ensemble_kalman_process.err
 end
 
 struct IterationSummary{P, E}

--- a/src/OceanTurbulenceParameterEstimation.jl
+++ b/src/OceanTurbulenceParameterEstimation.jl
@@ -2,7 +2,8 @@ module OceanTurbulenceParameterEstimation
 
 export OneDimensionalTimeSeries, InverseProblem, FreeParameters, 
         IdentityNormalization, ZScore, forward_map, observation_map,
-        eki, lognormal_with_mean_std, iterate!, EnsembleKalmanInversion
+        eki, lognormal_with_mean_std, iterate!, EnsembleKalmanInversion, UnscentedKalmanInversion, 
+        UnscentedKalmanInversionPostprocess, ConstrainedNormal
 
 include("Observations.jl")
 include("TurbulenceClosureParameters.jl")
@@ -12,6 +13,7 @@ include("EnsembleKalmanInversions.jl")
 using .Observations: OneDimensionalTimeSeries, ZScore
 using .TurbulenceClosureParameters: FreeParameters
 using .InverseProblems: InverseProblem, forward_map, observation_map
-using .EnsembleKalmanInversions: iterate!, EnsembleKalmanInversion, lognormal_with_mean_std
+using .EnsembleKalmanInversions: iterate!, EnsembleKalmanInversion, UnscentedKalmanInversion, 
+       UnscentedKalmanInversionPostprocess,  ConstrainedNormal, lognormal_with_mean_std
 
 end # module


### PR DESCRIPTION
In this PR, we add
1) ConstrainedNormal 
```
struct ConstrainedNormal{FT}
    # θ is the original constrained paramter, θ̃ is the unconstrained parameter ~ N(μ, σ)
    # θ = lower_bound + (upper_bound - lower_bound)/（1 + exp(θ̃)）
    μ::FT
    σ::FT
    lower_bound::FT
    upper_bound::FT
end
```

2) unscented Kalman inversion, which uses `ensemble_size = 2Nθ+1`

3) add an example, convective_adjustment_perfect_model_calibration_uki.jl, where we calibrate 2 parameters with unscented Kalman inversion

<img width="590" alt="Screen Shot 2021-10-22 at 4 36 24 PM" src="https://user-images.githubusercontent.com/16932196/138533801-761090e4-f1e6-42c2-9660-63322b7e9e15.png">

The truth parameters are [1, 1e-4], after 10 iterations, the estimated parameters are [1.06039, 0.000101061].
