### PR TITLE
Subtract variance when transforming Normally-distributed parameters

### DIFF
--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -213,7 +213,7 @@ and the inverse trasnform is the natural logarithm ``f^{-1} ≡ \\log``,
 \\log(Y) = X ∼ 𝒩(μ, σ).
 ```
 """
-transform_to_unconstrained(Π::Normal,    Y) = Y / abs(Π.μ)
+transform_to_unconstrained(Π::Normal,    Y) = (Y - Π.σ) / abs(Π.μ)
 transform_to_unconstrained(Π::LogNormal, Y) = log(Y^(1 / abs(Π.μ))) # log(Y) / abs(Π.μ)
 
 transform_to_unconstrained(Π::ScaledLogitNormal, Y) =
@@ -226,7 +226,7 @@ Transform an "unconstrained", normally-distributed variate `X`
 to "constrained" (physical) space via the map associated with
 the distribution `Π` of `Y`.
 """
-transform_to_constrained(Π::Normal, X)    = X * abs(Π.μ)
+transform_to_constrained(Π::Normal, X)    = (X * abs(Π.μ)) + Π.σ
 transform_to_constrained(Π::LogNormal, X) = exp(X * abs(Π.μ))
 
 transform_to_constrained(Π::ScaledLogitNormal, X) =


### PR DESCRIPTION
This PR updates `transform_to_unconstrained` and `transform_to_constrained` for `Normal`ly distributed parameters to subtract the distribution variance, in addition to normalizing by the distribution mean.

Opening on @adelinehillier's behalf.