### PR TITLE
Alternative normalization for `Normal`ly distributed parameters?

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ParameterEstimocean"
 uuid = "eca81dc5-87a6-4430-aec8-c76695404a43"
 license = "MIT"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.12.2"
+version = "0.13.0"
 
 [deps]
 DataDeps = "124859b0-ceae-595e-8997-d05f6a7a8dfe"

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -177,7 +177,7 @@ end
 
 # Calculate the prior in unconstrained space given a prior in constrained space
 unconstrained_prior(Π::LogNormal)         = Normal(Π.μ / abs(Π.μ), Π.σ / abs(Π.μ))
-unconstrained_prior(Π::Normal)            = Normal(Π.μ / abs(Π.μ), Π.σ / abs(Π.μ))
+unconstrained_prior(Π::Normal)            = Normal(Π.μ / Π.σ, 1)
 unconstrained_prior(Π::ScaledLogitNormal) = Normal(Π.μ, Π.σ)
 
 """
@@ -213,7 +213,7 @@ and the inverse trasnform is the natural logarithm ``f^{-1} ≡ \\log``,
 \\log(Y) = X ∼ 𝒩(μ, σ).
 ```
 """
-transform_to_unconstrained(Π::Normal,    Y) = (Y - Π.σ) / abs(Π.μ)
+transform_to_unconstrained(Π::Normal,    Y) = (Y - Π.μ) / Π.σ
 transform_to_unconstrained(Π::LogNormal, Y) = log(Y^(1 / abs(Π.μ))) # log(Y) / abs(Π.μ)
 
 transform_to_unconstrained(Π::ScaledLogitNormal, Y) =
@@ -226,7 +226,7 @@ Transform an "unconstrained", normally-distributed variate `X`
 to "constrained" (physical) space via the map associated with
 the distribution `Π` of `Y`.
 """
-transform_to_constrained(Π::Normal, X)    = (X * abs(Π.μ)) + Π.σ
+transform_to_constrained(Π::Normal, X)    = X * Π.σ + Π.μ
 transform_to_constrained(Π::LogNormal, X) = exp(X * abs(Π.μ))
 
 transform_to_constrained(Π::ScaledLogitNormal, X) =

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -177,7 +177,7 @@ end
 
 # Calculate the prior in unconstrained space given a prior in constrained space
 unconstrained_prior(Π::LogNormal)         = Normal(Π.μ / abs(Π.μ), Π.σ / abs(Π.μ))
-unconstrained_prior(Π::Normal)            = Normal(Π.μ / Π.σ, 1)
+unconstrained_prior(Π::Normal)            = Normal(0, 1)
 unconstrained_prior(Π::ScaledLogitNormal) = Normal(Π.μ, Π.σ)
 
 """


### PR DESCRIPTION
@adelinehillier, should we subtract the mean and divide by variance? We're doing the converse now (subtracting variance and dividing by mean). It seems dividing by the mean has undesirable effects, like the variance in unconstrained space diverging as the constrained mean approaches zero. For example, we can't have unconstrained parameters with unit normal distributions using this method. But subtracting mean and dividing by variance is always valid, and implies that the unconstrained prior is unit `Normal(0, 1)`.