### PR TITLE
Fix RescaledZScore

### DIFF
--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -219,7 +219,7 @@ struct RescaledZScore{T, Z} <: AbstractNormalization
     zscore :: Z
 end
 
-RescaledZScore(scale) = RescaledZScore(scale, nothing)
+RescaledZScore(scale) = RescaledZScore(scale, ZScore())
 
 compute_normalization(r::RescaledZScore, transformation, fts) =
     RescaledZScore(r.scale, compute_normalization(ZScore(), transformation, fts))

--- a/src/Transformations.jl
+++ b/src/Transformations.jl
@@ -222,7 +222,7 @@ end
 RescaledZScore(scale) = RescaledZScore(scale, nothing)
 
 compute_normalization(r::RescaledZScore, transformation, fts) =
-    RescaledZScore(r.scale, compute_normalization(r.zscore, transformation, fts))
+    RescaledZScore(r.scale, compute_normalization(ZScore(), transformation, fts))
 
 function normalize!(data, normalization::RescaledZScore)
     normalize!(data, normalization.zscore)


### PR DESCRIPTION
Previously `RescaledZScore` was rescaling the raw data rather than the zscore-normalized data.